### PR TITLE
Arregla el numero de fila que se envia al row mapper

### DIFF
--- a/S0923-01-data-access-jdbc/src/main/java/com/eiv/JdbcTemplate.java
+++ b/S0923-01-data-access-jdbc/src/main/java/com/eiv/JdbcTemplate.java
@@ -31,14 +31,13 @@ public class JdbcTemplate {
     }
     
     public <T> List<T> query(String sql, RowMapper<T> rowMapper) {
-        int rowNum = 0;
         ArrayList<T> result = new ArrayList<T>();
         try(Connection conn = dataSource.getConnection();
             PreparedStatement stmt = conn.prepareStatement(sql);
             ResultSet rs = stmt.executeQuery()) {
                 
                 while(rs.next()) {
-                    T t = rowMapper.mapRow(rs, rowNum);
+                    T t = rowMapper.mapRow(rs, rs.getRow());
                     result.add(t);
                 }
                 


### PR DESCRIPTION
Siempre se enviaba como número de fila 0 al row mapper. 
Para arreglarlo faltaba incrementar el rowNum dentro del while o como hice sacarlo directamente del result set.
Esto igual no afectaba nada en el ejemplo porque el row mapper no usaba el número de fila.
(de paso pruebo el pull request que nunca lo usé)